### PR TITLE
Multi-containers support

### DIFF
--- a/ext/kubernetes/deployment/deployment.go
+++ b/ext/kubernetes/deployment/deployment.go
@@ -23,16 +23,18 @@ var k8sErrorStatuses = []string{
 type Deployment struct {
 	Name          string
 	Namespace     string
+	ContainerName string
 	RepositoryURI string
 	Version       string
 	Config        string
 }
 
-func NewDeployment(component *bot.Component, version string) *Deployment {
+func NewDeployment(component *bot.Component, container *bot.Container, version string) *Deployment {
 	return &Deployment{
 		Name:          component.Name,
 		Namespace:     component.Namespace,
-		RepositoryURI: component.RepositoryURI,
+		ContainerName: container.Name,
+		RepositoryURI: container.RepositoryURI,
 		Version:       version,
 		Config:        component.BootstrapConfig,
 	}
@@ -50,7 +52,7 @@ func (d *Deployment) Apply() (bool, error) {
 
 		return false, nil
 	} else {
-		image := fmt.Sprintf("%v=%v:%v", d.Name, d.RepositoryURI, d.Version)
+		image := fmt.Sprintf("%v=%v:%v", d.ContainerName, d.RepositoryURI, d.Version)
 
 		_, err := executeKubectlCmd(d.Namespace, "set", "image", deploymentName, image)
 		if err != nil {

--- a/ext/kubernetes/deployment/init.go
+++ b/ext/kubernetes/deployment/init.go
@@ -15,6 +15,7 @@ const (
 	invalidAmountOfParams = "Invalid amount of parameters"
 	invalidParams         = "Invalid parameters"
 	componentNotFound     = "Component not found."
+	containerNotFound     = "Container not found."
 	deployInfo            = "Deploying the image tag `%v` from `%v`. It may take several seconds."
 	deployErrors          = "Some errors occurred :thinking_face:. Please, check the logs and try again in a few moments."
 	rollbackExecuted      = "Problems identified during the deployment, the rollback was executed successfully."
@@ -43,10 +44,14 @@ func Deploy(botCommand *bot.Cmd) (string, error) {
 	if component == nil {
 		return componentNotFound, nil
 	}
+	container := component.FindContainer(botCommand.Args[1])
+	if container == nil {
+		return containerNotFound, nil
+	}
 
 	username := botCommand.User.Nick
 	if bot.Cfg().IsSuperuser(username) || component.IsExecUser(username) {
-		deployment := NewDeployment(component, botCommand.Args[1])
+		deployment := NewDeployment(component, container, botCommand.Args[2])
 		err := postMessageToSlackChannel(
 			botCommand.Channel,
 			fmt.Sprintf(

--- a/pkg/bot/config.go
+++ b/pkg/bot/config.go
@@ -18,8 +18,8 @@ type Config struct {
 }
 
 type Component struct {
-	Name            string   `json:"name"`
-	RepositoryURI   string   `json:"repository-uri"`
+	Name            string `json:"name"`
+	Containers      []Container
 	BootstrapConfig string   `json:"bootstrap-config"`
 	Namespace       string   `json:"namespace"`
 	ExecUsers       []string `json:"exec-users"`
@@ -31,6 +31,11 @@ type Job struct {
 	Config    string   `json:"config"`
 	Namespace string   `json:"namespace"`
 	ExecUsers []string `json:"exec-users"`
+}
+
+type Container struct {
+	Name          string `json:"name"`
+	RepositoryURI string `json:"repository-uri"`
 }
 
 func (c *Config) Load(file string) error {
@@ -80,6 +85,15 @@ func (c *Config) FindJob(name string) *Job {
 	for _, j := range c.Jobs {
 		if j.Name == name {
 			return &j
+		}
+	}
+	return nil
+}
+
+func (c *Component) FindContainer(name string) *Container {
+	for _, cont := range c.Containers {
+		if cont.Name == name {
+			return &cont
 		}
 	}
 	return nil


### PR DESCRIPTION
Offer the possibility of having multiple-containers in a deployment via the configuration below in the `components` scope:

```
      "containers": [
        {
          "name": "container-name",
          "repository-uri": "docker-registry.com/image-name"
        }
      ],
```